### PR TITLE
TEST: Specify encoding in test_prologserver.py

### DIFF
--- a/python/test_prologserver.py
+++ b/python/test_prologserver.py
@@ -120,7 +120,7 @@ class TestPrologMQI(ParametrizedTestCase):
         if os.name == "nt":
             call = "TASKLIST", "/FI", "imagename eq %s" % process_name + ".exe"
             # use buildin check_output right away
-            output = subprocess.check_output(call).decode()
+            output = subprocess.check_output(call).decode(encoding='UTF-8', errors='replace')
             # check each line for process name
             count = 0
             for line in output.strip().split("\r\n"):


### PR DESCRIPTION
Fixes a problem for MSYS2. I hope my ad hoc fix is harmless.

````
ERROR: test_variable_attributes (test_prologserver.TestPrologMQI.test_variable_attributes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:/msys64/home/c7201178/swipl-devel/packages/mqi/python/test_prologserver.py", line 95, in setUp
    self.initialProcessCount = self.process_count("swipl")
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:/msys64/home/c7201178/swipl-devel/packages/mqi/python/test_prologserver.py", line 123, in process_count
    output = subprocess.check_output(call).decode()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 237: invalid start byte
````