### PR TITLE
Invoke python, not python3

### DIFF
--- a/BuildingAndTesting.md
+++ b/BuildingAndTesting.md
@@ -4,7 +4,7 @@
 3. Open a command window
 2. cd to the directory you created and:
 ~~~
-python3 -m venv ./env
+python -m venv ./env
 source env/bin/activate
 pip install swiplserver
 python test_prologserver.py
@@ -16,22 +16,22 @@ First do a build.  This will build into a directory called `/repository_root/pyt
 Make sure to increase the version number in `setup.cfg` before you build:
 ~~~
 cd /repository_root/python
-python3 -m venv ./env
+python -m venv ./env
 source env/bin/activate
 pip install build
 pip install twine
-python3 -m build
+python -m build
 ~~~
 Then, upload for testing in the "test Python Package Index": https://test.pypi.org/. You'll need to create an account there and get an API token to do this test.  
 
 You will be prompted for a username and password. For the username, use `__token__`. For the password, use the API token value, including the pypi- prefix.
 ~~~
-python3 -m twine upload --repository testpypi dist/*
+python -m twine upload --repository testpypi dist/*
 ~~~
 
 Or to upload for release (you'll need an account on http://www.pypi.org to do this):
 ~~~
-python3 -m twine upload dist/*
+python -m twine upload dist/*
 ~~~
 
 # Building documentation
@@ -43,7 +43,7 @@ HTML Docs produced with https://pdoc3.github.io like this:
 
 ~~~
 cd /repository_root/python
-python3 -m venv ./env
+python -m venv ./env
 source env/bin/activate
 pip install pdoc3
 pdoc --html --force --output-dir docs --config show_source_code=False swiplserver.prologmqi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ install_src(mqi_app
 	    RENAME mqi.pl
 	    DESTINATION ${SWIPL_INSTALL_APP})
 
-find_program(PROG_PYTHON NAMES python3)
+find_program(PROG_PYTHON NAMES python)
 
 if(PROG_PYTHON)
   test_libs(mqi

--- a/test_mqi.pl
+++ b/test_mqi.pl
@@ -55,7 +55,7 @@ has_python :-
 
 has_python(Prog) :-
     exe_options(Options),
-    absolute_file_name(path(python3), Prog, Options).
+    absolute_file_name(path(python), Prog, Options).
 
 exe_options(Options) :-
     current_prolog_flag(windows, true),


### PR DESCRIPTION
There isn't any support for python2 anymore, since 2020, and the windows installer does not install a python3.exe. So it is not found on Windows.

After this patch, we can run test_installation on Windows swipl.exe